### PR TITLE
Nautobot Playbook Cleanup

### DIFF
--- a/playbooks/nautobot_inventory.yml
+++ b/playbooks/nautobot_inventory.yml
@@ -1,8 +1,6 @@
 plugin: networktocode.nautobot.inventory
-api_endpoint: https://demo.nautobot.com/
+api_endpoint: https://192.0.2.12
 validate_certs: False
 config_context: False
 device_query_filters:
   - has_primary_ip: 'true'
-  - role: 'branch_wan'
-  

--- a/playbooks/nautobot_inventory.yml
+++ b/playbooks/nautobot_inventory.yml
@@ -1,6 +1,8 @@
 plugin: networktocode.nautobot.inventory
-api_endpoint: https://192.0.2.12
+api_endpoint: https://demo.nautobot.com/
 validate_certs: False
 config_context: False
 device_query_filters:
   - has_primary_ip: 'true'
+  - role: 'branch_wan'
+  

--- a/playbooks/pb_nautobot_sync.yml
+++ b/playbooks/pb_nautobot_sync.yml
@@ -4,89 +4,101 @@
   gather_facts: false
   vars_files:
     - ./vars/credentials.yml
-  vars: 
-    tags: []
 
   tasks:
-
     - name: Collect List of Sites from Nautobot
-      uri: 
-        url: "https://{{ nautobot_host }}/api/dcim/locations"
+      ansible.builtin.uri:
+        url: "https://{{ nautobot_host }}/api/dcim/locations/?limit=0"
         validate_certs: false
         headers:
-          authorization: "Token {{nautobot_token}}"
+          authorization: "Token {{ nautobot_token }}"
       register: nautobot_sites
       delegate_to: localhost
       run_once: true
 
     - name: Create the Site
-      kentik_site:
+      kentik.kentik_config.kentik_site:
         title: "{{ item['name'] }}"
         lat: "{{ item['latitude'] | int }}"
         lon: "{{ item['longitude'] | int }}"
         state: present
+        email: "{{ kentik_user }}"
+        token: "{{ kentik_token }}"
       delegate_to: localhost
       register: site_data
       run_once: true
       loop: "{{ nautobot_sites.json.results }}"
 
     - name: Gather Device Roles from Nautobot
-      uri: 
-        url: "https://{{ nautobot_host }}/api/extras/roles"
+      ansible.builtin.uri:
+        url: "https://{{ nautobot_host }}/api/extras/roles/?limit=0"
         validate_certs: false
         headers:
-          authorization: Token {{nautobot_token}}
+          authorization: Token {{ nautobot_token }}
       register: nautobot_roles
       delegate_to: localhost
       run_once: true
-    
+
     - name: Gather Tenants from Nautobot
-      uri: 
-        url: "https://{{ nautobot_host }}/api/tenancy/tenants"
+      ansible.builtin.uri:
+        url: "https://{{ nautobot_host }}/api/tenancy/tenants/?limit=0"
         validate_certs: false
         headers:
-          authorization: Token {{nautobot_token}}
+          authorization: Token {{ nautobot_token }}
       register: nautobot_tenants
       delegate_to: localhost
       run_once: true
-    
+
     - name: Gather Tags from Nautobot
-      uri: 
-        url: "https://{{ nautobot_host }}/api/extras/tags"
+      ansible.builtin.uri:
+        url: "https://{{ nautobot_host }}/api/extras/tags/?limit=0"
         validate_certs: false
         headers:
-          authorization: Token {{nautobot_token}}
+          authorization: Token {{ nautobot_token }}
       register: nautobot_tags
       delegate_to: localhost
       run_once: true
-    
+
     - name: Create Device Role Labels
-      kentik_label:
+      kentik.kentik_config.kentik_label:
         name: "{{ item['name'] }}"
+        color: "#{{ item['color'] }}"
+        email: "{{ kentik_user }}"
+        token: "{{ kentik_token }}"
       delegate_to: localhost
       loop: "{{ nautobot_roles.json.results }}"
       run_once: true
 
     - name: Create Tenant Labels
-      kentik_label:
+      kentik.kentik_config.kentik_label:
         name: "{{ item['name'] }}"
+        color: "#00ff00"
+        email: "{{ kentik_user }}"
+        token: "{{ kentik_token }}"
       delegate_to: localhost
       loop: "{{ nautobot_tenants.json.results }}"
       run_once: true
 
     - name: Create Tags Labels
-      kentik_label:
+      kentik.kentik_config.kentik_label:
         name: "{{ item['name'] }}"
+        color: "#{{ item['color'] }}"
+        email: "{{ kentik_user }}"
+        token: "{{ kentik_token }}"
       delegate_to: localhost
       loop: "{{ nautobot_tags.json.results }}"
       run_once: true
 
-    - name: Set Fact for Labels
-      set_fact:
-        tags: "{{ device_roles + tenants + tags }}"
+    - name: Set fact for labels
+      ansible.builtin.set_fact:
+        labels: "{{ device_roles + tenants + tags }}"
+
+    - name: Print labels
+      ansible.builtin.debug:
+        var: labels
 
     - name: Create Device
-      kentik_device:
+      kentik.kentik_config.kentik_device:
         deviceName: "{{ inventory_hostname }}"
         deviceSampleRate: 10
         planName: Free Flowpak Plan
@@ -95,9 +107,11 @@
         deviceSnmpIp: "{{ primary_ip4 }}"
         deviceSnmpCommunity: kentik
         nms:
-            agentId: "183"
-            ipAddress: "{{ primary_ip4 }}"
-            snmp:
-                credentialName: snmp_v2_read_only
-        labels: tags
+          agentId: "183"
+          ipAddress: "{{ primary_ip4 }}"
+          snmp:
+            credentialName: snmp_v2_read_only
+        labels: "{{ labels }}"
+        email: "{{ kentik_user }}"
+        token: "{{ kentik_token }}"
       delegate_to: localhost


### PR DESCRIPTION
This PR cleans up the Nautobot sync playbook:
- simple formatting
- added FQCNs
- added missling email and token fields for Kentik objects
- added missing required color fields for labels
- added api syntax to push query responses to their max size ( /?limit=0 , this is controlled by the env variable MAX_PAGE_SIZE) https://netboxlabs.com/docs/netbox/en/stable/integrations/rest-api/

