### PR TITLE
formatting to keep the linter happy

### DIFF
--- a/playbooks/hosts
+++ b/playbooks/hosts
@@ -1,0 +1,1 @@
+localhost

--- a/playbooks/nautobot_inventory.yml
+++ b/playbooks/nautobot_inventory.yml
@@ -4,3 +4,4 @@ validate_certs: False
 config_context: False
 device_query_filters:
   - has_primary_ip: 'true'
+  #- role: 'branch_wan'

--- a/playbooks/netbox_inventory.yml
+++ b/playbooks/netbox_inventory.yml
@@ -2,6 +2,7 @@ plugin: netbox.netbox.nb_inventory
 api_endpoint: https://127.0.0.1
 validate_certs: False
 config_context: False
+site_data: true
 device_query_filters:
   - has_primary_ip: 'true'
   #- tag: 'tag1'

--- a/playbooks/pb_nautobot_sync.yml
+++ b/playbooks/pb_nautobot_sync.yml
@@ -118,5 +118,4 @@
         labels: "{{ labels }}"
         email: "{{ kentik_user }}"
         token: "{{ kentik_token }}"
-        state: absent
       delegate_to: localhost

--- a/playbooks/pb_nautobot_sync.yml
+++ b/playbooks/pb_nautobot_sync.yml
@@ -115,7 +115,7 @@
           ipAddress: "{{ primary_ip4 }}"
           snmp:
             credentialName: snmp_v2_read_only
-        labels: "{{ label }}"
+        labels: "{{ labels }}"
         email: "{{ kentik_user }}"
         token: "{{ kentik_token }}"
         state: absent

--- a/playbooks/pb_nautobot_sync.yml
+++ b/playbooks/pb_nautobot_sync.yml
@@ -98,8 +98,8 @@
         var: labels
 
     - name: Print Tags
-      debug:
-        var: tags
+      ansible.builtin.debug:
+        var: labels
 
     - name: Create Device
       kentik.kentik_config.kentik_device:
@@ -115,7 +115,7 @@
           ipAddress: "{{ primary_ip4 }}"
           snmp:
             credentialName: snmp_v2_read_only
-        labels: "{{ tags }}"
+        labels: "{{ label }}"
         email: "{{ kentik_user }}"
         token: "{{ kentik_token }}"
         state: absent

--- a/playbooks/pb_netbox_sync.yml
+++ b/playbooks/pb_netbox_sync.yml
@@ -19,7 +19,7 @@
 
     - name: Create the sites
       kentik.kentik_config.kentik_site:
-        title: "{{ item['slug'] }}"
+        title: "{{ item['name'] }}"
         lat: "{{ item['latitude'] | int }}"
         lon: "{{ item['longitude'] | int }}"
         state: present
@@ -103,7 +103,7 @@
         deviceName: "{{ inventory_hostname }}"
         deviceSampleRate: 10
         planName: Free Flowpak Plan
-        siteName: "{{ sites[0] }}"
+        siteName: "{{ sites[0]['name'] }}"
         sendingIps: ["{{ primary_ip4 }}"]
         deviceSnmpIp: "{{ primary_ip4 }}"
         deviceSnmpCommunity: kentik
@@ -117,20 +117,20 @@
         email: "{{ kentik_user }}"
         token: "{{ kentik_token }}"
       delegate_to: localhost
-    
+
     - name: Sync Prefixes
       kentik.kentik_config.kentik_netbox_prefixes:
         netboxUrl: "https://{{ netbox_host }}"
         netboxToken: "{{ netbox_token }}"
-        enableTenant: True
+        enableTenant: true
         tenantName: "tenants"
-        enableSitebyIP: True
-        enableRoles: True
-        enableDescriptions: True
-        enableVlan: True
-        enableCustomFields: True
+        enableSitebyIP: true
+        enableRoles: true
+        enableDescriptions: true
+        enableVlan: true
+        enableCustomFields: true
         customFieldName: POD
-        activeOnly: True
+        activeOnly: true
         email: "{{ kentik_user }}"
         token: "{{ kentik_token }}"
         region: US

--- a/playbooks/pb_netbox_sync.yml
+++ b/playbooks/pb_netbox_sync.yml
@@ -121,7 +121,7 @@
     - name: Sync Prefixes
       kentik.kentik_config.kentik_netbox_prefixes:
         netboxUrl: "https://{{ netbox_host }}"
-        netboxToken: "{{netbox_token}}"
+        netboxToken: "{{ netbox_token }}"
         enableTenant: True
         tenantName: "tenants"
         enableSitebyIP: True


### PR DESCRIPTION
Changed the way sites are created. We had been using the slug for the name but we've changed it to use the full name of the site. This meant that we need to have the inventory include more than the default data. 

Other minor edits and formatting. 
