### PR TITLE
Comment out prefix

### DIFF
--- a/playbooks/pb_netbox_sync.yml
+++ b/playbooks/pb_netbox_sync.yml
@@ -136,3 +136,4 @@
     #     region: US
     #   delegate_to: localhost
     #   run_once: true
+# 

--- a/playbooks/pb_netbox_sync.yml
+++ b/playbooks/pb_netbox_sync.yml
@@ -118,21 +118,21 @@
         token: "{{ kentik_token }}"
       delegate_to: localhost
 
-    - name: Sync Prefixes
-      kentik.kentik_config.kentik_netbox_prefixes:
-        netboxUrl: "https://{{ netbox_host }}"
-        netboxToken: "{{ netbox_token }}"
-        enableTenant: true
-        tenantName: "tenants"
-        enableSitebyIP: true
-        enableRoles: true
-        enableDescriptions: true
-        enableVlan: true
-        enableCustomFields: true
-        customFieldName: POD
-        activeOnly: true
-        email: "{{ kentik_user }}"
-        token: "{{ kentik_token }}"
-        region: US
-      delegate_to: localhost
-      run_once: true
+    # - name: Sync Prefixes
+    #   kentik.kentik_config.kentik_netbox_prefixes:
+    #     netboxUrl: "https://{{ netbox_host }}"
+    #     netboxToken: "{{ netbox_token }}"
+    #     enableTenant: true
+    #     tenantName: "tenants"
+    #     enableSitebyIP: true
+    #     enableRoles: true
+    #     enableDescriptions: true
+    #     enableVlan: true
+    #     enableCustomFields: true
+    #     customFieldName: POD
+    #     activeOnly: true
+    #     email: "{{ kentik_user }}"
+    #     token: "{{ kentik_token }}"
+    #     region: US
+    #   delegate_to: localhost
+    #   run_once: true


### PR DESCRIPTION

For now I'm commenting out the prefix sync section until we can get a better set of defaults. It requires some config modification, so disabling ahead of our next workshop.

